### PR TITLE
Update validation annotation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins
 {
-	id 'org.springframework.boot' version '2.7.0' 
+	id 'org.springframework.boot' version '2.7.18' 
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'eclipse'
@@ -36,13 +36,13 @@ dependencies
     // Spring Boot web starter dependency
     implementation("org.springframework.boot:spring-boot-starter-web")
   
-    // Validation (Annotation support, for validating Web input forms)  
-    implementation("org.springframework.boot:spring-boot-starter-validation");
+    // Validation anotation support, for validating Web input forms  
+    implementation("javax.validation:validation-api");
   	
     // Spring Boot thymeleaf view dependency
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
-    // Don't include TomCat in the runtime build, but do put it in WEB-INF so it can be run standalone a well as embedded
+    // Don't include TomCat in the runtime build, but put it in lib-provided so it can run standalone as well as embedded
     providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
   
     // CICS TS V5.5 Maven BOM (as of 19th May 2020)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins
 {
-	id 'org.springframework.boot' version '2.7.18' 
+	id 'org.springframework.boot' version '2.7.0' 
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'eclipse'
@@ -14,7 +14,6 @@ archivesBaseName='cics-java-liberty-springboot-link'
 version = '0.1.0'
 sourceCompatibility = '1.8'
 
-
 // If in Eclipse, add Javadoc to the local project classpath
 eclipse 
 {
@@ -24,12 +23,10 @@ eclipse
     }
 }
 
-
 repositories 
 {
     mavenCentral()
 }
-
 
 dependencies 
 {
@@ -55,10 +52,8 @@ dependencies
     // Don't include JCICS components in the final build (no need for version because we have BOM)
     compileOnly("com.ibm.cics:com.ibm.cics.server")                 
     compileOnly ("com.ibm.cics:com.ibm.cics.server.invocation.annotations")
-  
     
 }
-
 
 
 publishing {

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,11 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     
-    <!-- Validation (Annotation support, for validating Web input forms) -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
-    </dependency>
+   <!-- Validation annotation support for validating Web input forms -->
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+		</dependency>
 		
     <!-- Thymeleaf view -->
     <dependency>
@@ -64,7 +64,7 @@
       <artifactId>spring-boot-starter-thymeleaf</artifactId>
     </dependency>
 
-    <!-- Don't include TomCat in the runtime build, but do put it in WEB-INF so it can be run standalone a well as embedded -->
+    <!-- Don't include TomCat in the runtime build, but put it in lib-provided so it can run standalone as well as embedded  -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>


### PR DESCRIPTION
Replace spring-boot-starter-validation with javax.validation to simplify build and enable compliance with Java EE7 support in Liberty Update a comments in build files for clarity