### PR TITLE
Add tiles-el dependency if using JSF

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For an IDE, taking Eclipse as an example, the plug-ins for Gradle *buildship* an
 
 The required build-tasks are typically `clean bootWar` for Gradle and `clean package` for Maven. Once run, Gradle will generate a WAR file in the `build/libs` directory, while Maven will generate it in the `target` directory.
 
+**Note:**
+If the Liberty server uses the JSF feature then the application build should add a dependency for tiles-el. This is required because javax.el.ELResolver is eligible for injection as mandated by the JSF specification and failure to add this to the build will cause a java.lang.NoClassDefFoundError for org.apache.tiles.el.ScopeELResolver at application startup.
+
 **Note:** When building a WAR file for deployment to Liberty it is good practice to exclude Tomcat from the final runtime artifact. We demonstrate this in the pom.xml with the *provided* scope, and in build.gradle with the *providedRuntime()* dependency.
 
 **Note:** If you import the project to your IDE, you might experience local project compile errors. To resolve these errors you should run a tooling refresh on that project. For example, in Eclipse: right-click on "Project", select "Gradle -> Refresh Gradle Project", **or** right-click on "Project", select "Maven -> Update Project...".

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For an IDE, taking Eclipse as an example, the plug-ins for Gradle *buildship* an
 The required build-tasks are typically `clean bootWar` for Gradle and `clean package` for Maven. Once run, Gradle will generate a WAR file in the `build/libs` directory, while Maven will generate it in the `target` directory.
 
 **Note:**
-If the Liberty server uses the JSF feature then the application build should add a dependency for tiles-el. This is required because javax.el.ELResolver is eligible for injection as mandated by the JSF specification and failure to add this to the build will cause a java.lang.NoClassDefFoundError for org.apache.tiles.el.ScopeELResolver at application startup.
+If the Liberty server uses the JSF feature then the application build should add a dependency for tiles-el. This is required because javax.el.ELResolver is eligible for injection as mandated by the JSF specification and failure to add this to the build will cause a `java.lang.NoClassDefFoundError` for `org.apache.tiles.el.ScopeELResolver` at application startup.
 
 **Note:** When building a WAR file for deployment to Liberty it is good practice to exclude Tomcat from the final runtime artifact. We demonstrate this in the pom.xml with the *provided* scope, and in build.gradle with the *providedRuntime()* dependency.
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,9 @@ dependencies
     // Don't include JCICS components in the final build (no need for version because we have BOM)
     compileOnly("com.ibm.cics:com.ibm.cics.server")                 
     compileOnly ("com.ibm.cics:com.ibm.cics.server.invocation.annotations")
-    
+
+    //Add tiles-el dependency if using JSF, see READ for more details 
+    implementation ("org.apache.tiles:tiles-el:3.0.8")    
 }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
   <!-- Inherit defaults from Spring Boot Parent-->
   <parent>
     <groupId>org.springframework.boot</groupId>
-	  <artifactId>spring-boot-starter-parent</artifactId>
-      <version>2.7.0</version>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.0</version>
   </parent>
 
   <!--  Application properties -->
@@ -15,11 +15,11 @@
   <artifactId>cics-java-liberty-springboot-link</artifactId>
   <version>0.1.0</version>
   <name>cics-java-liberty-springboot-link</name>
-  <description>Demo project for Spring Boot</description>	
+  <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>1.8</java.version>
   </properties>
-	
+
   <!-- CICS TS V5.5 BOM (as of May 2020) -->
   <dependencyManagement>
     <dependencies>
@@ -34,30 +34,31 @@
   </dependencyManagement>
 
   <dependencies>
-    <!-- Compile against, but don't include JCICS in the final build (version and scope are from BOM) -->
+    <!-- Compile against, but don't include JCICS in the final build (version and scope are from
+    BOM) -->
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>com.ibm.cics.server</artifactId>
     </dependency>
-    
+
     <!-- CICS Annotations -->
     <dependency>
       <groupId>com.ibm.cics</groupId>
       <artifactId>com.ibm.cics.server.invocation.annotations</artifactId>
     </dependency>
-           
-    <!-- Spring web support --> 
+
+    <!-- Spring web support -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
-    
-   <!-- Validation annotation support for validating Web input forms -->
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-		</dependency>
-		
+
+    <!-- Validation annotation support for validating Web input forms -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
+
     <!-- Thymeleaf view -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -69,25 +70,33 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
       <scope>provided</scope>
-    </dependency>		
+    </dependency>
+
+    <!-- Add tiles-el dependency if using JSF, see README for more details -->
+    <dependency>
+      <groupId>org.apache.tiles</groupId>
+      <artifactId>tiles-el</artifactId>
+      <version>3.0.8</version>
+    </dependency>
+
   </dependencies>
-	
+
   <!-- Package as an executable war (default jar) -->
   <packaging>war</packaging>
-	
+
   <!-- Build with Maven and CICS annotation processor -->
   <build>
-    <plugins>    
+    <plugins>
       <!-- Spring Boot plugin for Maven -->
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
-            
+
       <!-- Enable the Link to Liberty annotation processor -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>	  	  
+        <configuration>
           <annotationProcessorPaths>
             <annotationProcessorPath>
               <groupId>com.ibm.cics</groupId>
@@ -99,9 +108,9 @@
       </plugin>
     </plugins>
   </build>
-	
 
-    <!-- 
+
+  <!-- 
     Publishes artifacts to here if the deploy goal is used. 
 
     The values here can be passed on the maven command line
@@ -110,15 +119,15 @@
     for example:
     -Dpublish_repo_snapshots_name=my-repo 
     -->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>${publish_repo_snapshots_name}</id>
-            <url>${publish_repo_snapshots_url}</url>
-        </snapshotRepository>
-        <repository>
-            <id>${publish_repo_releases_name}</id>
-            <url>${publish_repo_releases_url}</url>
-        </repository>
-    </distributionManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>${publish_repo_snapshots_name}</id>
+      <url>${publish_repo_snapshots_url}</url>
+    </snapshotRepository>
+    <repository>
+      <id>${publish_repo_releases_name}</id>
+      <url>${publish_repo_releases_url}</url>
+    </repository>
+  </distributionManagement>
 
 </project>


### PR DESCRIPTION
Added tiles-el dependency to maven and gradle build files to circumvent a NCDF Exception when using the JSF feature in Liberty.