### PR TITLE
Validation fixes: build config, CI workflow, Eclipse settings, Maven wrapper

### DIFF
--- a/cics-java-liberty-springboot-link-app/.classpath
+++ b/cics-java-liberty-springboot-link-app/.classpath
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="com.ibm.cics.core.ui.CICS_LIBRARY/CICS TS V6.1 with Java EE and Liberty 8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
+	<classpathentry kind="con" path="com.ibm.cics.explorer.sdk.web.LIBERTY_LIBRARIES/L./V.61/JE.JEE_V10_R0">
 		<attributes>
 			<attribute name="owner.project.facets" value="jst.web"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
-	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>


### PR DESCRIPTION
Commits:
- Fix io.spring.dependency-management version
- Publish readiness fixes
- Update app .classpath: use correct CICS Liberty Libraries container path (V6.1, Jakarta EE 10)